### PR TITLE
Support new `roster` endpoint and update PerscomFactory to align with SDK

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=8.2",
         "forumify/forumify-platform": "^0.3.0",
-        "deschutesdesigngroupllc/perscom-php-sdk": "2.0",
+        "deschutesdesigngroupllc/perscom-php-sdk": "^2.0",
         "league/commonmark": "^2.5"
     },
     "autoload": {

--- a/src/Admin/Form/SettingsType.php
+++ b/src/Admin/Form/SettingsType.php
@@ -18,13 +18,9 @@ class SettingsType extends AbstractType
             ->add('perscom__endpoint', TextType::class, [
                 'label' => 'Endpoint',
             ])
-            ->add('perscom__perscom_id', TextType::class, [
-                'label' => 'PERSCOM ID',
-                'help' => 'Can be found on your PERSCOM dashboard, under "System" > "Settings".',
-            ])
             ->add('perscom__api_key', PasswordType::class, [
                 'label' => 'API Key',
-                'help' => 'Create a new API key for forumify on your PERSCOM dashboard, under "System" > "API" > "Keys". Remember to add all scopes!',
+                'help' => 'Create a new API key for forumify on your PERSCOM dashboard, under "Integrations" > "API Keys". Select "All scopes" to allow the API key to access every resource.',
                 'required' => false,
             ]);
     }

--- a/src/Admin/Form/SettingsType.php
+++ b/src/Admin/Form/SettingsType.php
@@ -18,6 +18,11 @@ class SettingsType extends AbstractType
             ->add('perscom__endpoint', TextType::class, [
                 'label' => 'Endpoint',
             ])
+            ->add('perscom__perscom_id', TextType::class, [
+                'label' => 'PERSCOM ID',
+                'required' => false,
+                'help' => 'Can be found on your PERSCOM dashboard. This is not required.',
+            ])
             ->add('perscom__api_key', PasswordType::class, [
                 'label' => 'API Key',
                 'help' => 'Create a new API key for forumify on your PERSCOM dashboard, under "Integrations" > "API Keys". Select "All scopes" to allow the API key to access every resource.',

--- a/src/Admin/Form/SettingsType.php
+++ b/src/Admin/Form/SettingsType.php
@@ -21,7 +21,7 @@ class SettingsType extends AbstractType
             ->add('perscom__perscom_id', TextType::class, [
                 'label' => 'PERSCOM ID',
                 'required' => false,
-                'help' => 'Can be found on your PERSCOM dashboard. This is not required.',
+                'help' => 'Can be found on your PERSCOM dashboard. This is optional. Your PERSCOM ID can be resolved using your API Key.',
             ])
             ->add('perscom__api_key', PasswordType::class, [
                 'label' => 'API Key',

--- a/src/Forum/Components/Roster.php
+++ b/src/Forum/Components/Roster.php
@@ -41,18 +41,12 @@ class Roster
             return [];
         }
 
-        $groups = $this->perscomFactory
+        $group = $this->perscomFactory
             ->getPerscom()
-            ->groups()
-            ->search(
-                scope: new ScopeObject('orderForRoster', [$groupId]),
+            ->roster()
+            ->group(
+                id: $groupId,
                 include: [
-                    'units',
-                    'units.users',
-                    'units.users.position',
-                    'units.users.rank',
-                    'units.users.rank.image',
-                    'units.users.status',
                     'units.secondary_assignment_records',
                     'units.secondary_assignment_records.position',
                     'units.secondary_assignment_records.user',
@@ -63,7 +57,6 @@ class Roster
             )
             ->json('data') ?? [];
 
-        $group = reset($groups) ?: [];
         return $this->mergeSecondaryUnitsIntoPrimary($group);
     }
 

--- a/src/Perscom/Perscom.php
+++ b/src/Perscom/Perscom.php
@@ -13,17 +13,12 @@ class Perscom extends PerscomConnection
     public const DATE_FORMAT = 'Y-m-d\TH:i:s.u\Z';
 
     public function __construct(
-        private readonly string $endpoint,
+        string $endpoint,
         string $apiKey,
         string $perscomId,
         private readonly bool $bypassCache = false,
     ) {
-        parent::__construct($apiKey, $perscomId);
-    }
-
-    public function resolveBaseUrl(): string
-    {
-        return $this->endpoint;
+        parent::__construct($apiKey, $perscomId, $endpoint);
     }
 
     protected function defaultHeaders(): array


### PR DESCRIPTION
The main reason for this PR is to switch to the new `roster` endpoint. This performs a `GET` request rather than a `POST` request which allows our caching service to improve the API performance. Under the hood, the requests are identical on PERSCOM's side. The `roster` endpoint auto-includes the following relations:

```
'image',
'units',
'units.image',
'units.users',
'units.users.position',
'units.users.rank',
'units.users.rank.image',
'units.users.specialty',
'units.users.status',
```

As you can see there are a few more default relations included (image, unit image, and user specialty) that you did not originally include when using the `groups` endpoint. You may not use these resources in this plugin but it should not hurt you to have them returned in the API response.

We left the secondary assignment relation includes in the request as those are unique to this plugin, but not default on the `roster` endpoint.