### PR TITLE
Update submissions tab to use grid

### DIFF
--- a/templates/frontend/operations_center/tabs/submissions.html.twig
+++ b/templates/frontend/operations_center/tabs/submissions.html.twig
@@ -1,5 +1,5 @@
-<div id="submissions" class="grid-12">
-    <div class="col-xs-12 col-sm-6 col-md-7 mr-5">
+<div id="submissions" class="grid-12 gap-4">
+    <div class="col-xs-12 col-sm-6 col-md-7">
         {{ component('SubmissionList', { userId: user.id }) }}
     </div>
     <div class="col-xs-12 col-sm-6 col-md-5 flex flex-col gap-2">

--- a/templates/frontend/operations_center/tabs/submissions.html.twig
+++ b/templates/frontend/operations_center/tabs/submissions.html.twig
@@ -1,8 +1,8 @@
-<div id="submissions" class="flex gap-4">
-    <div class="w-70">
+<div id="submissions" class="grid-12">
+    <div class="col-xs-12 col-sm-6 col-md-7 mr-5">
         {{ component('SubmissionList', { userId: user.id }) }}
     </div>
-    <div class="w-30 flex flex-col gap-2">
+    <div class="col-xs-12 col-sm-6 col-md-5 flex flex-col gap-2">
         {% if plugin_version('forumify/forumify-perscom-plugin', 'premium') and setting('perscom.report_in.enabled') %}
             {{ component('Perscom\\ReportInButton') }}
         {% endif %}


### PR DESCRIPTION
Current submissions twig does not use the grid system, making it unusable in small devices (tested on my own Samsung S23).
This PR makes a slight modification to the structure of the submissions.html.twig file, so that when browsing in small devices, the list of available forms will flow to the bottom instead of being cutoff on the side.

Elements should share the same row on smaller resolutions and then beginning with medium it should take the approximate original structure.
In order to keep the list of submissions and the buttons separate, a margin is added on the first column (because i'm kind of a newb with CSS) and it does not look too disruptive in mobile.